### PR TITLE
Add backlog collision resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,25 @@ A curated list of collision detection open resources
 | Name | Shapes | Features | Languages | Licenses | Code | Popularity |
 |:----:| ------ | -------- | --------- | -------- | ---- | ---------- |
 | [BEPUphysics 1](http://www.bepuphysics.com/) | (todo) | (todo) | C#, .NET | Apache v2 | [github](https://github.com/bepu/bepuphysics1) | ![bepuphysics1](https://img.shields.io/github/stars/bepu/bepuphysics1.svg?style=social&label=Star&maxAge=2592000) |
+| [Box2D](https://box2d.org) | Circle<br/>Capsule<br/>Segment<br/>Polygon<br/>Chain | 2D<br/>Collision<br/>Distance<br/>Continuous Collision Detection<br/>Ray Cast<br/>Shape Cast | C | MIT | [github](https://github.com/erincatto/box2d) | ![box2d](https://img.shields.io/github/stars/erincatto/box2d.svg?style=social&label=Star&maxAge=2592000) |
 | [Bullet](http://bulletphysics.org) | (todo) | (todo) | C++, Python | Zlib | [github](https://github.com/bulletphysics/bullet3) | ![bullet3](https://img.shields.io/github/stars/bulletphysics/bullet3.svg?style=social&label=Star&maxAge=2592000) |
+| [CCD-Wrapper](https://github.com/Continuous-Collision-Detection/CCD-Wrapper) | Vertex-Face<br/>Edge-Edge | Continuous Collision Detection<br/>Benchmark | C++ | MIT | [github](https://github.com/Continuous-Collision-Detection/CCD-Wrapper) | ![CCD-Wrapper](https://img.shields.io/github/stars/Continuous-Collision-Detection/CCD-Wrapper.svg?style=social&label=Star&maxAge=2592000) |
 | collision-rs | (todo) | (todo) | Rust | Apache-2.0 | [github](https://github.com/rustgd/collision-rs) | ![collision-rs](https://img.shields.io/github/stars/rustgd/collision-rs.svg?style=social&label=Star&maxAge=2592000) |
 | [FCL](https://github.com/flexible-collision-library/fcl) | (todo) | (todo) | C++ | BSD-3-Clause | [github](https://github.com/flexible-collision-library/fcl) | ![fcl](https://img.shields.io/github/stars/flexible-collision-library/fcl.svg?style=social&label=Star&maxAge=2592000) |
 | [coal (HPP-FCL)](https://github.com/coal-library/coal) | Box<br/>Sphere<br/>Cylinder<br/>Capsule<br/>Ellipsoid<br/>Cone<br/>Meshes<br/>Convex Meshes<br/>Height Field | Collision<br/>Distance<br/>Security Margins | C++, Python | BSD-3-Clause | [github](https://github.com/coal-library/coal) | ![hpp-fcl](https://img.shields.io/github/stars/humanoid-path-planner/hpp-fcl.svg?style=social&label=Star&maxAge=2592000) |
 | [JitterPhysics](https://github.com/mattleibow/jitterphysics) | (todo) | (todo) | C#, .NET | MIT | [github](https://github.com/mattleibow/jitterphysics) | ![jitterphysics](https://img.shields.io/github/stars/mattleibow/jitterphysics.svg?style=social&label=Star&maxAge=2592000) |
+| [Kraft](https://github.com/BeRo1985/kraft) | Sphere<br/>Capsule<br/>Box<br/>Convex Hull<br/>Triangle Mesh | Collision<br/>Continuous Collision Detection<br/>Distance<br/>Ray Cast<br/>Sphere Cast | Object Pascal | Zlib | [github](https://github.com/BeRo1985/kraft) | ![kraft](https://img.shields.io/github/stars/BeRo1985/kraft.svg?style=social&label=Star&maxAge=2592000) |
 | [libccd](https://github.com/danfis/libccd) | (todo) | (todo) | C | BSD-3-Clause | [github](https://github.com/danfis/libccd) | ![libccd](https://img.shields.io/github/stars/danfis/libccd.svg?style=social&label=Star&maxAge=2592000) |
+| [MuJoCo](https://mujoco.org/) | Sphere<br/>Capsule<br/>Box<br/>Cylinder<br/>Plane<br/>Mesh<br/>Height Field | Collision<br/>Contact<br/>Distance<br/>Multibody Dynamics | C++, Python | Apache-2.0 | [github](https://github.com/google-deepmind/mujoco) | ![mujoco](https://img.shields.io/github/stars/google-deepmind/mujoco.svg?style=social&label=Star&maxAge=2592000) |
 | [ncollide](http://ncollide.org/) | (todo) | (todo) | Rust | BSD-3-Clause | [github](https://github.com/sebcrozet/ncollide) | ![ncollide](https://img.shields.io/github/stars/sebcrozet/ncollide.svg?style=social&label=Star&maxAge=2592000) |
 | [ODE](http://www.ode.org/) | Sphere<br/>Box<br/>Cylinder<br/>Capsule<br/>Plane<br/>Ray<br/>Triangular-mesh | (todo) | C++, [Python](http://pyode.sourceforge.net/) | LGPL-2.1 or BSD-3-Clause | [bitbucket](https://bitbucket.org/odedevs/ode) |  |
 | [OpenGJK](https://www.mattiamontanari.com/opengjk/) | (todo) | (todo) | C++, C#, Go, Matlab, Python, Unity | GPL-3.0 | [github](https://github.com/MattiaMontanari/openGJK) | ![openGJK](https://img.shields.io/github/stars/MattiaMontanari/openGJK.svg?style=social&label=Star&maxAge=2592000) |
 | [Parry](https://github.com/dimforge/parry) | (todo) | (todo) | Rust | Apache-2.0 | [github](https://github.com/dimforge/parry) | ![parry](https://img.shields.io/github/stars/dimforge/parry.svg?style=social&label=Star&maxAge=2592000) |
+| [PhysX](https://nvidia-omniverse.github.io/PhysX/) | Sphere<br/>Capsule<br/>Box<br/>Plane<br/>Convex Mesh<br/>Triangle Mesh<br/>Height Field | Collision<br/>Scene Query<br/>Contact<br/>Rigid Body Dynamics | C++ | BSD-3-Clause | [github](https://github.com/NVIDIA-Omniverse/PhysX) | ![PhysX](https://img.shields.io/github/stars/NVIDIA-Omniverse/PhysX.svg?style=social&label=Star&maxAge=2592000) |
+| [python-fcl](https://github.com/BerkeleyAutomation/python-fcl) | Box<br/>Sphere<br/>Ellipsoid<br/>Capsule<br/>Cone<br/>Convex<br/>Cylinder<br/>Half-space<br/>Plane<br/>Mesh<br/>OcTree | Collision<br/>Distance<br/>Continuous Collision Detection | Python, Cython | BSD-3-Clause | [github](https://github.com/BerkeleyAutomation/python-fcl) | ![python-fcl](https://img.shields.io/github/stars/BerkeleyAutomation/python-fcl.svg?style=social&label=Star&maxAge=2592000) |
+| [pytorch_volumetric](https://github.com/UM-ARM-Lab/pytorch_volumetric) | Mesh<br/>Voxel Grid<br/>Signed Distance Field | Distance<br/>SDF<br/>Collision Checking<br/>Differentiable Queries | Python | MIT | [github](https://github.com/UM-ARM-Lab/pytorch_volumetric) | ![pytorch_volumetric](https://img.shields.io/github/stars/UM-ARM-Lab/pytorch_volumetric.svg?style=social&label=Star&maxAge=2592000) |
 | [ReactPhysics3d](http://www.reactphysics3d.com/) | (todo) | (todo) | C++ | Zlib | [github](https://github.com/DanielChappuis/reactphysics3d) | ![reactphysics3d](https://img.shields.io/github/stars/DanielChappuis/reactphysics3d.svg?style=social&label=Star&maxAge=2592000) |
+| [Tight-Inclusion](https://continuous-collision-detection.github.io/tight_inclusion/) | Vertex-Face<br/>Edge-Edge | Continuous Collision Detection<br/>Minimum Separation<br/>Conservative Collision Detection | C++ | MIT | [github](https://github.com/Continuous-Collision-Detection/Tight-Inclusion) | ![Tight-Inclusion](https://img.shields.io/github/stars/Continuous-Collision-Detection/Tight-Inclusion.svg?style=social&label=Star&maxAge=2592000) |
 | tinyc2 | (todo) | 2d | C/C++ | Zlib | [github](https://github.com/RandyGaul/tinyheaders) | ![tinyheaders](https://img.shields.io/github/stars/RandyGaul/tinyheaders.svg?style=social&label=Star&maxAge=2592000) |
 | qu3e | (todo) | (todo) | C++ | Zlib | [github](https://github.com/RandyGaul/qu3e) | ![qu3e](https://img.shields.io/github/stars/RandyGaul/qu3e.svg?style=social&label=Star&maxAge=2592000) |
 
@@ -47,6 +55,7 @@ A curated list of collision detection open resources
 
 * [bounding-mesh](http://www.boundingmesh.com/) ([github](https://github.com/gaschler/bounding-mesh) ![bounding-mesh](https://img.shields.io/github/stars/gaschler/bounding-mesh.svg?style=social&label=Star&maxAge=2592000)) - Implementation of the bounding mesh and bounding convex decomposition algorithms for single-sided mesh approximation.
 * cinolib ([github](https://github.com/mlivesu/cinolib) ![cinolib](https://img.shields.io/github/stars/mlivesu/cinolib.svg?style=social&label=Star&maxAge=2592000)) - A generic programming header only C++ library for processing polygonal and polyhedral meshes.
+* [CoACD](https://colin97.github.io/CoACD/) ([github](https://github.com/SarahWeiii/CoACD) ![CoACD](https://img.shields.io/github/stars/SarahWeiii/CoACD.svg?style=social&label=Star&maxAge=2592000)) - Approximate convex decomposition for collision-aware mesh approximation.
 * [libigl](https://libigl.github.io/) ([github](https://github.com/libigl/libigl) ![libigl](https://img.shields.io/github/stars/libigl/libigl.svg?style=social&label=Star&maxAge=2592000)) - A simple C++ geometry processing library.
 
 ## [Papers](#awesome-collision-detection)
@@ -73,6 +82,7 @@ A curated list of collision detection open resources
 #### Mesh Collision
 
 * Robust contact generation for robot simulation with unstructured meshes (2013), K. Hauser. [[pdf](https://motion.cs.illinois.edu/papers/ISRR2013-RobustContact.pdf), [web](http://motion.cs.illinois.edu/simulation/index.html)]
+* Approximate Convex Decomposition for 3D Meshes with Collision-Aware Concavity and Tree Search (2022), X. Wei et al. [[pdf](https://arxiv.org/pdf/2205.02961), [project](https://colin97.github.io/CoACD/), [code](https://github.com/SarahWeiii/CoACD), [video](https://www.youtube.com/watch?v=r12O0z0723s)]
 
 #### Penetration Depth Computation
 
@@ -126,6 +136,7 @@ A curated list of collision detection open resources
 #### Benchmark
 
 * [spatial-collision-datastructures](https://github.com/ttvd/spatial-collision-datastructures) - Benchmark of various spatial data structures for collision detection.
+* [Continuous Collision Detection](https://continuous-collision-detection.github.io/) ([code](https://github.com/continuous-collision-detection)) Project page for continuous collision detection papers, implementations, benchmarks, and datasets.
 
 #### Narrow-phase
 

--- a/data/articles.yaml
+++ b/data/articles.yaml
@@ -18,6 +18,13 @@
   url: https://github.com/ttvd/spatial-collision-datastructures
   description: '- Benchmark of various spatial data structures for collision detection.'
   _subsection: Benchmark
+- name: Continuous Collision Detection
+  url: https://continuous-collision-detection.github.io/
+  description: Project page for continuous collision detection papers, implementations, benchmarks, and datasets.
+  links:
+  - label: code
+    url: https://github.com/continuous-collision-detection
+  _subsection: Benchmark
 - name: Algorithm table for narrowphase algorithms
   url: http://www.realtimerendering.com/intersections.html
   _subsection: Narrow-phase

--- a/data/libraries.yaml
+++ b/data/libraries.yaml
@@ -7,6 +7,27 @@
   license: Apache v2
   github: bepu/bepuphysics1
   badge_github: bepu/bepuphysics1
+- name: Box2D
+  _subsection: Active
+  url: https://box2d.org
+  shapes:
+  - Circle
+  - Capsule
+  - Segment
+  - Polygon
+  - Chain
+  features:
+  - 2D
+  - Collision
+  - Distance
+  - Continuous Collision Detection
+  - Ray Cast
+  - Shape Cast
+  languages:
+  - C
+  license: MIT
+  github: erincatto/box2d
+  badge_github: erincatto/box2d
 - name: Bullet
   _subsection: Active
   url: http://bulletphysics.org
@@ -16,6 +37,20 @@
   license: Zlib
   github: bulletphysics/bullet3
   badge_github: bulletphysics/bullet3
+- name: CCD-Wrapper
+  _subsection: Active
+  url: https://github.com/Continuous-Collision-Detection/CCD-Wrapper
+  shapes:
+  - Vertex-Face
+  - Edge-Edge
+  features:
+  - Continuous Collision Detection
+  - Benchmark
+  languages:
+  - C++
+  license: MIT
+  github: Continuous-Collision-Detection/CCD-Wrapper
+  badge_github: Continuous-Collision-Detection/CCD-Wrapper
 - name: collision-rs
   _subsection: Active
   languages:
@@ -63,6 +98,26 @@
   license: MIT
   github: mattleibow/jitterphysics
   badge_github: mattleibow/jitterphysics
+- name: Kraft
+  _subsection: Active
+  url: https://github.com/BeRo1985/kraft
+  shapes:
+  - Sphere
+  - Capsule
+  - Box
+  - Convex Hull
+  - Triangle Mesh
+  features:
+  - Collision
+  - Continuous Collision Detection
+  - Distance
+  - Ray Cast
+  - Sphere Cast
+  languages:
+  - Object Pascal
+  license: Zlib
+  github: BeRo1985/kraft
+  badge_github: BeRo1985/kraft
 - name: libccd
   _subsection: Active
   url: https://github.com/danfis/libccd
@@ -71,6 +126,28 @@
   license: BSD-3-Clause
   github: danfis/libccd
   badge_github: danfis/libccd
+- name: MuJoCo
+  _subsection: Active
+  url: https://mujoco.org/
+  shapes:
+  - Sphere
+  - Capsule
+  - Box
+  - Cylinder
+  - Plane
+  - Mesh
+  - Height Field
+  features:
+  - Collision
+  - Contact
+  - Distance
+  - Multibody Dynamics
+  languages:
+  - C++
+  - Python
+  license: Apache-2.0
+  github: google-deepmind/mujoco
+  badge_github: google-deepmind/mujoco
 - name: ncollide
   _subsection: Active
   url: http://ncollide.org/
@@ -116,6 +193,69 @@
   license: Apache-2.0
   github: dimforge/parry
   badge_github: dimforge/parry
+- name: PhysX
+  _subsection: Active
+  url: https://nvidia-omniverse.github.io/PhysX/
+  shapes:
+  - Sphere
+  - Capsule
+  - Box
+  - Plane
+  - Convex Mesh
+  - Triangle Mesh
+  - Height Field
+  features:
+  - Collision
+  - Scene Query
+  - Contact
+  - Rigid Body Dynamics
+  languages:
+  - C++
+  license: BSD-3-Clause
+  github: NVIDIA-Omniverse/PhysX
+  badge_github: NVIDIA-Omniverse/PhysX
+- name: python-fcl
+  _subsection: Active
+  url: https://github.com/BerkeleyAutomation/python-fcl
+  shapes:
+  - Box
+  - Sphere
+  - Ellipsoid
+  - Capsule
+  - Cone
+  - Convex
+  - Cylinder
+  - Half-space
+  - Plane
+  - Mesh
+  - OcTree
+  features:
+  - Collision
+  - Distance
+  - Continuous Collision Detection
+  languages:
+  - Python
+  - Cython
+  license: BSD-3-Clause
+  github: BerkeleyAutomation/python-fcl
+  badge_github: BerkeleyAutomation/python-fcl
+- name: pytorch_volumetric
+  _subsection: Active
+  url: https://github.com/UM-ARM-Lab/pytorch_volumetric
+  shapes:
+  - Mesh
+  - Voxel Grid
+  - Signed Distance Field
+  features:
+  - Distance
+  - SDF
+  - Collision Checking
+  - Differentiable Queries
+  languages:
+  - Python
+  license: MIT
+  github: UM-ARM-Lab/pytorch_volumetric
+  badge_github: UM-ARM-Lab/pytorch_volumetric
 - name: ReactPhysics3d
   _subsection: Active
   url: http://www.reactphysics3d.com/
@@ -124,6 +264,21 @@
   license: Zlib
   github: DanielChappuis/reactphysics3d
   badge_github: DanielChappuis/reactphysics3d
+- name: Tight-Inclusion
+  _subsection: Active
+  url: https://continuous-collision-detection.github.io/tight_inclusion/
+  shapes:
+  - Vertex-Face
+  - Edge-Edge
+  features:
+  - Continuous Collision Detection
+  - Minimum Separation
+  - Conservative Collision Detection
+  languages:
+  - C++
+  license: MIT
+  github: Continuous-Collision-Detection/Tight-Inclusion
+  badge_github: Continuous-Collision-Detection/Tight-Inclusion
 - name: tinyc2
   _subsection: Active
   features:

--- a/data/mesh-processing.yaml
+++ b/data/mesh-processing.yaml
@@ -7,6 +7,11 @@
   github: mlivesu/cinolib
   badge_github: mlivesu/cinolib
   description: A generic programming header only C++ library for processing polygonal and polyhedral meshes.
+- name: CoACD
+  url: https://colin97.github.io/CoACD/
+  github: SarahWeiii/CoACD
+  badge_github: SarahWeiii/CoACD
+  description: Approximate convex decomposition for collision-aware mesh approximation.
 - name: libigl
   url: https://libigl.github.io/
   github: libigl/libigl

--- a/data/papers.yaml
+++ b/data/papers.yaml
@@ -66,6 +66,17 @@
   - label: web
     url: http://motion.cs.illinois.edu/simulation/index.html
   _subsection: Mesh Collision
+- name: Approximate Convex Decomposition for 3D Meshes with Collision-Aware Concavity and Tree Search (2022), X. Wei et al.
+  links:
+  - label: pdf
+    url: https://arxiv.org/pdf/2205.02961
+  - label: project
+    url: https://colin97.github.io/CoACD/
+  - label: code
+    url: https://github.com/SarahWeiii/CoACD
+  - label: video
+    url: https://www.youtube.com/watch?v=r12O0z0723s
+  _subsection: Mesh Collision
 - name: 'PolyDepth: Real-time Penetration Depth Computation using Iterative Contact-Space Projection (2012), C. Je et al.'
   links:
   - label: pdf


### PR DESCRIPTION
## Summary
- add accepted active library entries from the open issue backlog: Box2D, Kraft, PhysX, python-fcl, MuJoCo, pytorch_volumetric, CCD-Wrapper, and Tight-Inclusion
- add CoACD to mesh processing and its referenced convex decomposition paper to Papers
- add the Continuous Collision Detection organization/project page as a benchmark resource
- regenerate README.md from the structured data

Closes #4
Closes #5
Closes #14
Closes #18
Closes #19

## Validation
- `python3 scripts/validate_entries.py`
- `python3 scripts/generate_readme.py`
- `python3 scripts/generate_readme.py -o /tmp/generated-awesome-collision-detection-readme.md` and `diff -q README.md /tmp/generated-awesome-collision-detection-readme.md`
- `python3 -m py_compile scripts/add_entry_from_payload.py scripts/github_metadata.py scripts/validate_entries.py scripts/fetch_metadata.py scripts/evaluate_entry.py scripts/generate_readme.py scripts/parse_readme.py`
- `git diff --check`